### PR TITLE
ceph_osd_df fails processing an OSD being down/out during usage calculat...

### DIFF
--- a/ceph-report-tool/modules/ceph_osd_df.py
+++ b/ceph-report-tool/modules/ceph_osd_df.py
@@ -10,6 +10,10 @@ for OSD in obj['pgmap']['osd_stats']:
 	outline="{0:5d}\t".format(OSD['osd'])
 	for i in [ 'kb', 'kb_used', 'kb_avail' ]:
 		outline+="{0:12d}\t".format(OSD[i])
-	usep=float(OSD['kb_used'])/float(OSD['kb'])*100;
+        if float(OSD['kb']) == 0.0: 
+	   usep=0.0
+        else:
+	   usep=float(OSD['kb_used'])/float(OSD['kb'])*100;
 	print outline+"{0:6.2f}".format(usep)
+
 


### PR DESCRIPTION
...ion. Added a fix to check the used size returned being 0 to avoid failing on divide by zero

Signed-off-by: JCL <jc.lopez@optimexa.com>