### PR TITLE
ceph_osd_df: If OSD is marked down the parser will fail.

### DIFF
--- a/ceph-report-tool/modules/ceph_osd_df.py
+++ b/ceph-report-tool/modules/ceph_osd_df.py
@@ -7,9 +7,12 @@ obj=json.load(sys.stdin)
 
 print "  OSD\t        Size\t        Used\t       Avail\t  Use%"
 for OSD in obj['pgmap']['osd_stats']:
-	outline="{0:5d}\t".format(OSD['osd'])
-	for i in [ 'kb', 'kb_used', 'kb_avail' ]:
-		outline+="{0:12d}\t".format(OSD[i])
-	usep=float(OSD['kb_used'])/float(OSD['kb'])*100;
-	print outline+"{0:6.2f}".format(usep)
+    outline="{0:5d}\t".format(OSD['osd'])
+    for i in [ 'kb', 'kb_used', 'kb_avail' ]:
+        outline+="{0:12d}\t".format(OSD[i])
+    try:
+        usep=float(OSD['kb_used'])/float(OSD['kb'])*100
+    except:
+        usep=float(0)
+    print outline+"{0:6.2f}".format(usep)
 


### PR DESCRIPTION
Added exception and set values to 0.

Signed-off-by: Tyler Brekke <tbrekke@redhat.com>